### PR TITLE
Add FastAPI backend scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,9 @@ Create a virtual environment and install requirements:
 uv venv
 uv pip install -r requirements.txt
 ```
+
+Run the development server:
+
+```bash
+uvicorn backend.app.main:app --reload
+```

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+async def read_root():
+    return {"message": "Hello, World!"}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>RAG Inspector</title>
+</head>
+<body>
+    <h1>RAG Inspector Frontend</h1>
+    <p>Placeholder for frontend assets.</p>
+</body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,4 +8,10 @@ version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = []
+dependencies = [
+    "fastapi",
+    "uvicorn",
+    "pydantic",
+    "python-multipart",
+    "jinja2",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+pydantic
+python-multipart
+jinja2


### PR DESCRIPTION
## Summary
- declare backend and frontend dependencies
- create FastAPI app with uvicorn entrypoint
- add placeholder frontend
- explain how to install requirements and run the server in README

## Testing
- `uv pip install --system -r requirements.txt`
- `python backend/app/main.py` (server started and was terminated)

------
https://chatgpt.com/codex/tasks/task_e_68405a0ca678832f9610af1cfae8f941