### PR TITLE
Add question generation and answer evaluation services

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pydantic import BaseSettings
+from typing import List
+
+
+class Settings(BaseSettings):
+    """Application configuration settings."""
+
+    chunk_size: int = 1000
+    chunk_stride: int = 200
+    rag_versions: List[str] = ["v1", "v2"]
+
+
+settings = Settings()

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,0 +1,4 @@
+from .question_generator import QuestionGenerator
+from .answer_evaluator import AnswerEvaluator
+
+__all__ = ["QuestionGenerator", "AnswerEvaluator"]

--- a/backend/app/services/answer_evaluator.py
+++ b/backend/app/services/answer_evaluator.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+from ..core.config import settings
+
+
+class AnswerEvaluator:
+    """Evaluate answers from different RAG system versions."""
+
+    def __init__(self, versions: List[str] | None = None) -> None:
+        self.versions = versions or settings.rag_versions
+
+    def answer(self, question: str) -> Dict[str, str]:
+        """Return answers from all configured RAG versions."""
+        responses: Dict[str, str] = {}
+        for version in self.versions:
+            responses[version] = self._query_system(version, question)
+        return responses
+
+    def _query_system(self, version: str, question: str) -> str:
+        """Stubbed RAG system call."""
+        # Replace with real RAG pipeline call for ``version``.
+        return f"{version} says: response to '{question}'"

--- a/backend/app/services/question_generator.py
+++ b/backend/app/services/question_generator.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+from uuid import uuid4
+
+from ..core.config import settings
+from ..models import GeneratedQuestion
+from ..utils import extract_text, chunk_text
+
+
+class QuestionGenerator:
+    """Create questions from document text chunks."""
+
+    def __init__(self, chunk_size: int | None = None, chunk_stride: int | None = None):
+        self.chunk_size = chunk_size or settings.chunk_size
+        self.chunk_stride = chunk_stride or settings.chunk_stride
+
+    def generate_from_file(self, doc_id: str, path: Path) -> List[GeneratedQuestion]:
+        """Extract text from ``path`` and generate questions for ``doc_id``."""
+        text = extract_text(path)
+        return self.generate_from_text(doc_id, text)
+
+    def generate_from_text(self, doc_id: str, text: str) -> List[GeneratedQuestion]:
+        """Generate questions for ``doc_id`` using supplied ``text``."""
+        chunks = chunk_text(text, window_size=self.chunk_size, stride=self.chunk_stride)
+        questions: List[GeneratedQuestion] = []
+        for _idx, chunk in chunks:
+            qtext = self._llm_generate_question(chunk)
+            questions.append(
+                GeneratedQuestion(
+                    question_id=str(uuid4()), document_id=doc_id, text=qtext
+                )
+            )
+        return questions
+
+    def _llm_generate_question(self, chunk: str) -> str:
+        """Stubbed LLM call to create a question for a text chunk."""
+        # Replace this with a real LLM integration.
+        snippet = chunk[:50].replace("\n", " ")
+        return f"What is discussed in: '{snippet}'?"


### PR DESCRIPTION
## Summary
- add Settings class for configurable chunking and RAG versions
- implement `QuestionGenerator` to chunk docs and generate questions
- implement `AnswerEvaluator` to return answers for each RAG version

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840f9c444f8832f98fed87ca5fe1422